### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/blender_tests.yml
+++ b/.github/workflows/blender_tests.yml
@@ -1,4 +1,6 @@
 name: Blender Tests
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/jordanblakey/blender-scripting/security/code-scanning/3](https://github.com/jordanblakey/blender-scripting/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly set the permissions for the `GITHUB_TOKEN` to `contents: read`, which is sufficient for the workflow's operations. This change ensures that the workflow does not inadvertently gain unnecessary write permissions.

The `permissions` block will be added immediately after the `name` field in the workflow file, applying the permissions to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
