### PR TITLE
feat: Add Ruff formatter configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,5 +91,5 @@ skip_covered = false
 [tool.ruff]
 line-length = 80
 exclude = [
-    "static",
+    "static/**",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ omit = [
 show_missing = true
 skip_covered = false
 
-[tool.ruff.format]
+[tool.ruff]
 line-length = 80
 exclude = [
     "static",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,3 +87,9 @@ omit = [
 [tool.coverage.report]
 show_missing = true
 skip_covered = false
+
+[tool.ruff.format]
+line-length = 80
+exclude = [
+    "static",
+]


### PR DESCRIPTION
Adds a [tool.ruff.format] section to pyproject.toml.

Key configurations:
- Line length set to 80 characters.
- Excludes the `static/` directory from formatting.
- Other project directories (butils, tests, scripts, experiments, .github) will be formatted by Ruff.

This configuration aims to establish consistent code formatting across the project's Python files according to widely accepted standards, while respecting the specified line length and directory exclusions.