### PR TITLE
add markdown linting to pre-commit hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,17 @@ butils/
 └── ui.py  # Work with the Blender UI: get contexts, control viewport
 ```
 
+### Pre-commit Hooks & Code Quality
+
+This project uses pre-commit hooks to ensure code quality and consistency. These hooks are automatically installed when you run `git commit` for the first time after cloning, or by running `scripts/install_githooks.sh`.
+
+The hooks currently perform:
+- Python linting and formatting using `ruff`.
+- Shell script linting and formatting using `shfmt` and `shellcheck`.
+- Markdown linting and formatting using `pymarkdownlnt` (for linting) and `mdformat` (for formatting).
+
+The Markdown tools (`pymarkdownlnt` and `mdformat`) are included as development dependencies in `pyproject.toml` and will be installed into the project's virtual environment when you run `poetry install`. The pre-commit script utilizes these tools from the Poetry environment.
+
 ## Unit tests
 
 This project uses Python's built-in `unittest` module for testing. Tests are executed within a Docker container that includes Blender, ensuring a consistent testing environment. This setup is defined in the GitHub Actions workflow file (`.github/workflows/blender_tests.yml`).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,8 @@ colorama = "^0.4.6"
 [tool.poetry.group.dev.dependencies]
 ruff = "^0.11.12"
 poethepoet = "^0.34.0"
+pymarkdownlnt = "^0.9.16"
+mdformat = "^0.7.17"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/scripts/githooks/pre-commit
+++ b/scripts/githooks/pre-commit
@@ -3,49 +3,49 @@
 
 set -e
 
-printf "\e[33mpre-commit hook \e[0m\n"
+printf "\033[33mpre-commit hook \033[0m\n"
 
 # ensure the pre-commit uses the correct python environment
 poetry env use python3
 eval $(poetry env activate | sed 's/source/./')
 
-printf "\e[35mruff format . \e[0m\n"
+printf "\033[35mruff format . \033[0m\n"
 # format: auto fix as much as possible
 ruff format .
 
-printf "\e[35mruff check . \e[0m\n"
+printf "\033[35mruff check . \033[0m\n"
 # lint: what couldn't be fixed
 ruff check .
 
 # Lint and format Markdown files (Python-based)
-printf "\e[35mFormatting and linting Markdown files (Python-based)...\e[0m\n"
+printf "\033[35mFormatting and linting Markdown files (Python-based)...\033[0m\n"
 STAGED_MD_FILES=$(git diff --cached --name-only --diff-filter=ACM "*.md")
 
 if [ -n "$STAGED_MD_FILES" ]; then
-  printf "\e[36mRunning mdformat on staged Markdown files:\e[0m\n"
+  printf "\033[36mRunning mdformat on staged Markdown files:\033[0m\n"
   echo "$STAGED_MD_FILES" | xargs -r python -m mdformat
   # Re-stage files modified by mdformat
   # Important: Ensure this git add command is run so changes by mdformat are included in the commit.
   echo "$STAGED_MD_FILES" | xargs -r git add
 
-  printf "\e[36mRunning pymarkdownlnt on staged Markdown files:\e[0m\n"
+  printf "\033[36mRunning pymarkdownlnt on staged Markdown files:\033[0m\n"
   # The 'scan' subcommand is default if paths are provided.
   # Pass the files listed in STAGED_MD_FILES to pymarkdownlnt.
   # xargs will pass them as arguments to the command.
   if ! echo "$STAGED_MD_FILES" | xargs -r python -m pymarkdownlnt scan; then
-    printf "\e[31mMarkdown linting errors found with pymarkdownlnt. Aborting commit.\e[0m\n"
+    printf "\033[31mMarkdown linting errors found with pymarkdownlnt. Aborting commit.\033[0m\n"
     # pymarkdownlnt already prints its own errors to stderr.
     exit 1
   fi
-  printf "\e[32mMarkdown files processed successfully with Python tools.\e[0m\n"
+  printf "\033[32mMarkdown files processed successfully with Python tools.\033[0m\n"
 else
-  printf "\e[32mNo staged Markdown files to process.\e[0m\n"
+  printf "\033[32mNo staged Markdown files to process.\033[0m\n"
 fi
 
 # lint and format shell scripts
 ./scripts/shfmt_and_shellcheck.sh
 
-printf "\e[35mrunning tests \e[0m\n"
+printf "\033[35mrunning tests \033[0m\n"
 gh act push
 
-printf "\e[32mpre-commit hook complete \e[0m\n"
+printf "\033[32mpre-commit hook complete \033[0m\n"

--- a/scripts/githooks/pre-commit
+++ b/scripts/githooks/pre-commit
@@ -3,49 +3,49 @@
 
 set -e
 
-printf "\033[33mpre-commit hook \033[0m\n"
+printf "\e[33mpre-commit hook \e[0m\n"
 
 # ensure the pre-commit uses the correct python environment
 poetry env use python3
 eval $(poetry env activate | sed 's/source/./')
 
-printf "\033[35mruff format . \033[0m\n"
+printf "\e[35mruff format . \e[0m\n"
 # format: auto fix as much as possible
 ruff format .
 
-printf "\033[35mruff check . \033[0m\n"
+printf "\e[35mruff check . \e[0m\n"
 # lint: what couldn't be fixed
 ruff check .
 
 # Lint and format Markdown files (Python-based)
-printf "\033[35mFormatting and linting Markdown files (Python-based)...\033[0m\n"
+printf "\e[35mFormatting and linting Markdown files (Python-based)...\e[0m\n"
 STAGED_MD_FILES=$(git diff --cached --name-only --diff-filter=ACM "*.md")
 
 if [ -n "$STAGED_MD_FILES" ]; then
-  printf "\033[36mRunning mdformat on staged Markdown files:\033[0m\n"
+  printf "\e[36mRunning mdformat on staged Markdown files:\e[0m\n"
   echo "$STAGED_MD_FILES" | xargs -r python -m mdformat
   # Re-stage files modified by mdformat
   # Important: Ensure this git add command is run so changes by mdformat are included in the commit.
   echo "$STAGED_MD_FILES" | xargs -r git add
 
-  printf "\033[36mRunning pymarkdownlnt on staged Markdown files:\033[0m\n"
+  printf "\e[36mRunning pymarkdownlnt on staged Markdown files:\e[0m\n"
   # The 'scan' subcommand is default if paths are provided.
   # Pass the files listed in STAGED_MD_FILES to pymarkdownlnt.
   # xargs will pass them as arguments to the command.
   if ! echo "$STAGED_MD_FILES" | xargs -r python -m pymarkdownlnt scan; then
-    printf "\033[31mMarkdown linting errors found with pymarkdownlnt. Aborting commit.\033[0m\n"
+    printf "\e[31mMarkdown linting errors found with pymarkdownlnt. Aborting commit.\e[0m\n"
     # pymarkdownlnt already prints its own errors to stderr.
     exit 1
   fi
-  printf "\033[32mMarkdown files processed successfully with Python tools.\033[0m\n"
+  printf "\e[32mMarkdown files processed successfully with Python tools.\e[0m\n"
 else
-  printf "\033[32mNo staged Markdown files to process.\033[0m\n"
+  printf "\e[32mNo staged Markdown files to process.\e[0m\n"
 fi
 
 # lint and format shell scripts
 ./scripts/shfmt_and_shellcheck.sh
 
-printf "\033[35mrunning tests \033[0m\n"
+printf "\e[35mrunning tests \e[0m\n"
 gh act push
 
-printf "\033[32mpre-commit hook complete \033[0m\n"
+printf "\e[32mpre-commit hook complete \e[0m\n"

--- a/scripts/githooks/pre-commit
+++ b/scripts/githooks/pre-commit
@@ -3,24 +3,49 @@
 
 set -e
 
-printf "\033[33mpre-commit hook \033[0m\n"
+printf "\e[33mpre-commit hook \e[0m\n"
 
 # ensure the pre-commit uses the correct python environment
 poetry env use python3
 eval $(poetry env activate | sed 's/source/./')
 
-printf "\033[35mruff format . \033[0m\n"
+printf "\e[35mruff format . \e[0m\n"
 # format: auto fix as much as possible
 ruff format .
 
-printf "\033[35mruff check . \033[0m\n"
+printf "\e[35mruff check . \e[0m\n"
 # lint: what couldn't be fixed
 ruff check .
+
+# Lint and format Markdown files (Python-based)
+printf "\e[35mFormatting and linting Markdown files (Python-based)...\e[0m\n"
+STAGED_MD_FILES=$(git diff --cached --name-only --diff-filter=ACM "*.md")
+
+if [ -n "$STAGED_MD_FILES" ]; then
+  printf "\e[36mRunning mdformat on staged Markdown files:\e[0m\n"
+  echo "$STAGED_MD_FILES" | xargs -r python -m mdformat
+  # Re-stage files modified by mdformat
+  # Important: Ensure this git add command is run so changes by mdformat are included in the commit.
+  echo "$STAGED_MD_FILES" | xargs -r git add
+
+  printf "\e[36mRunning pymarkdownlnt on staged Markdown files:\e[0m\n"
+  # The 'scan' subcommand is default if paths are provided.
+  # Pass the files listed in STAGED_MD_FILES to pymarkdownlnt.
+  # xargs will pass them as arguments to the command.
+  if ! echo "$STAGED_MD_FILES" | xargs -r python -m pymarkdownlnt scan; then
+    printf "\e[31mMarkdown linting errors found with pymarkdownlnt. Aborting commit.\e[0m\n"
+    # pymarkdownlnt already prints its own errors to stderr.
+    exit 1
+  fi
+  printf "\e[32mMarkdown files processed successfully with Python tools.\e[0m\n"
+else
+  printf "\e[32mNo staged Markdown files to process.\e[0m\n"
+fi
 
 # lint and format shell scripts
 ./scripts/shfmt_and_shellcheck.sh
 
-printf "\033[35mrunning tests \033[0m\n"
+printf "\e[35mrunning tests \e[0m\n"
 gh act push
 
-printf "\033[32mpre-commit hook complete \033[0m\n"
+printf "\e[32mpre-commit hook complete \e[0m\n"


### PR DESCRIPTION
Updated `scripts/githooks/pre-commit` to use `\e[...m` string representations for all ANSI color escape codes in `printf` statements.

This change ensures that:
- Color codes are represented as readable strings in the source code, instead of raw/literal escape characters (which can appear as unprintable or confusing characters like '[' in some editors).
- The script maintains its colored output for better user experience during pre-commit checks.

This addresses feedback regarding the format of escape codes in the script.